### PR TITLE
Support Linux and port to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.15)
+project(VMPAttach)
+
+include(FetchContent)
+
+FetchContent_Declare(
+    VTIL-Core
+    GIT_REPOSITORY https://github.com/vtil-project/VTIL-Core
+    GIT_SHALLOW    true
+)
+FetchContent_MakeAvailable(VTIL-Core)
+
+add_subdirectory(VMPAttack)

--- a/VMPAttack/CMakeLists.txt
+++ b/VMPAttack/CMakeLists.txt
@@ -1,0 +1,42 @@
+add_executable(VMPAttack
+    analysis_context.cpp
+    analysis_context.hpp
+    arithmetic_expression.cpp
+    arithmetic_expression.hpp
+    arithmetic_operation.cpp
+    arithmetic_operation_desc.hpp
+    arithmetic_operation.hpp
+    arithmetic_operations.hpp
+    arithmetic_utilities.hpp
+    disassembler.cpp
+    disassembler.hpp
+    flags.hpp
+    instruction.cpp
+    instruction.hpp
+    instruction_stream.cpp
+    instruction_stream.hpp
+    instruction_utilities.hpp
+    main.cpp
+    vm_analysis_context.hpp
+    vm_bridge.cpp
+    vm_bridge.hpp
+    vm_context.hpp
+    vmentry.hpp
+    vm_handler.cpp
+    vm_handler.hpp
+    vm_instance.cpp
+    vm_instance.hpp
+    vm_instruction.cpp
+    vm_instruction_desc.hpp
+    vm_instruction.hpp
+    vm_instruction_info.hpp
+    vm_instruction_set.hpp
+    vmpattack.cpp
+    vmpattack.hpp
+    vm_state.hpp
+)
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
+target_link_libraries(VMPAttack PRIVATE VTIL Threads::Threads)

--- a/VMPAttack/arithmetic_operations.hpp
+++ b/VMPAttack/arithmetic_operations.hpp
@@ -1,5 +1,9 @@
 #pragma once
+#ifdef _WIN32
 #include <intrin.h>
+#else
+#include <x86intrin.h>
+#endif
 #include "arithmetic_operation_desc.hpp"
 #include "instruction.hpp"
 
@@ -19,9 +23,30 @@ namespace vmpattack
 
         // Bitwise Byte-Swaps.
         //
-        inline const arithmetic_operation_desc bswap_64 = { X86_INS_BSWAP,  0, []( uint64_t d, const uint64_t a[] ) -> uint64_t { return _byteswap_uint64( d ); }, 8 };
-        inline const arithmetic_operation_desc bswap_32 = { X86_INS_BSWAP,  0, []( uint64_t d, const uint64_t a[] ) -> uint64_t { return _byteswap_ulong( ( uint32_t )d ); }, 4 };
-        inline const arithmetic_operation_desc bswap_16 = { X86_INS_BSWAP,  0, []( uint64_t d, const uint64_t a[] ) -> uint64_t { return _byteswap_ushort( ( uint16_t )d ); }, 2 };
+        //         inline const arithmetic_operation_desc bswap_64 = { X86_INS_BSWAP,  0, []( uint64_t d, const uint64_t a[] ) -> uint64_t { return __bswap_64( d ); }, 8 };
+        // inline const arithmetic_operation_desc bswap_32 = { X86_INS_BSWAP,  0, []( uint64_t d, const uint64_t a[] ) -> uint64_t { return __bswap_32( ( uint32_t )d ); }, 4 };
+        // inline const arithmetic_operation_desc bswap_16 = { X86_INS_BSWAP,  0, []( uint64_t d, const uint64_t a[] ) -> uint64_t { return __bswap_16( ( uint16_t )d ); }, 2 };
+        inline const arithmetic_operation_desc bswap_64 = { X86_INS_BSWAP,  0, []( uint64_t d, const uint64_t a[] ) -> uint64_t {
+#ifdef _WIN32
+            return _byteswap_uint64( d );
+#else
+            return __bswap_64( d );
+#endif
+        }, 8 };
+        inline const arithmetic_operation_desc bswap_32 = { X86_INS_BSWAP,  0, []( uint64_t d, const uint64_t a[] ) -> uint64_t {
+#ifdef _WIN32
+            return _byteswap_ulong( ( uint32_t )d );
+#else
+            return __bswap_32( ( uint32_t )d );
+#endif
+        }, 4 };
+        inline const arithmetic_operation_desc bswap_16 = { X86_INS_BSWAP,  0, []( uint64_t d, const uint64_t a[] ) -> uint64_t {
+#ifdef _WIN32
+            return _byteswap_ushort( ( uint16_t )d );
+#else
+            return __bswap_16( ( uint16_t )d );
+#endif
+        }, 2 };
 
         // Incement / Decrement.
         //
@@ -36,17 +61,65 @@ namespace vmpattack
 
         // Left Bitwise Rotations.
         //
-        inline const arithmetic_operation_desc brol_64 = { X86_INS_ROL,    1, []( uint64_t d, const uint64_t a[] ) -> uint64_t { return _rotl64( d, ( int )a[ 0 ] ); }, 8 };
-        inline const arithmetic_operation_desc brol_32 = { X86_INS_ROL,    1, []( uint64_t d, const uint64_t a[] ) -> uint64_t { return _rotl( ( uint32_t )d, ( int )a[ 0 ] ); }, 4 };
-        inline const arithmetic_operation_desc brol_16 = { X86_INS_ROL,    1, []( uint64_t d, const uint64_t a[] ) -> uint64_t { return _rotl16( ( uint16_t )d, ( uint8_t )a[ 0 ] ); }, 2 };
-        inline const arithmetic_operation_desc brol_8 = { X86_INS_ROL,    1, []( uint64_t d, const uint64_t a[] ) -> uint64_t { return _rotl8( ( uint8_t )d, ( uint8_t )a[ 0 ] ); }, 1 };
+        inline const arithmetic_operation_desc brol_64 = { X86_INS_ROL,    1, []( uint64_t d, const uint64_t a[] ) -> uint64_t {
+#ifdef _WIN32
+            return _rotl64( d, ( int )a[ 0 ] );
+#else
+            return __rolq( d, ( int )a[ 0 ] );
+#endif
+        }, 8 };
+        inline const arithmetic_operation_desc brol_32 = { X86_INS_ROL,    1, []( uint64_t d, const uint64_t a[] ) -> uint64_t {
+#ifdef _WIN32
+            return _rotl( ( uint32_t )d, ( int )a[ 0 ] );
+#else
+            return __rold( ( uint32_t )d, ( int )a[ 0 ] );
+#endif
+        }, 4 };
+        inline const arithmetic_operation_desc brol_16 = { X86_INS_ROL,    1, []( uint64_t d, const uint64_t a[] ) -> uint64_t {
+#ifdef _WIN32
+            return _rotl16( ( uint16_t )d, ( uint8_t )a[ 0 ] );
+#else
+            return __rolw( ( uint16_t )d, ( uint8_t )a[ 0 ] );
+#endif
+        }, 2 };
+        inline const arithmetic_operation_desc brol_8 = { X86_INS_ROL,    1, []( uint64_t d, const uint64_t a[] ) -> uint64_t {
+#ifdef _WIN32
+            return _rotl8( ( uint8_t )d, ( uint8_t )a[ 0 ] );
+#else
+            return __rolb( ( uint8_t )d, ( uint8_t )a[ 0 ] );
+#endif
+        }, 1 };
 
         // Right Bitwise Rotations.
         //
-        inline const arithmetic_operation_desc bror_64 = { X86_INS_ROR,    1, []( uint64_t d, const uint64_t a[] ) -> uint64_t { return _rotr64( d, ( int )a[ 0 ] ); }, 8 };
-        inline const arithmetic_operation_desc bror_32 = { X86_INS_ROR,    1, []( uint64_t d, const uint64_t a[] ) -> uint64_t { return _rotr( ( uint32_t )d, ( int )a[ 0 ] ); }, 4 };
-        inline const arithmetic_operation_desc bror_16 = { X86_INS_ROR,    1, []( uint64_t d, const uint64_t a[] ) -> uint64_t { return _rotr16( ( uint16_t )d, ( uint8_t )a[ 0 ] ); }, 2 };
-        inline const arithmetic_operation_desc bror_8 = { X86_INS_ROR,    1, []( uint64_t d, const uint64_t a[] ) -> uint64_t { return _rotr8( ( uint8_t )d, ( uint8_t )a[ 0 ] ); }, 1 };
+        inline const arithmetic_operation_desc bror_64 = { X86_INS_ROR,    1, []( uint64_t d, const uint64_t a[] ) -> uint64_t {
+#ifdef _WIN32
+            return _rotr64( d, ( int )a[ 0 ] );
+#else
+            return __rorq( d, ( int )a[ 0 ] );
+#endif
+        }, 8 };
+        inline const arithmetic_operation_desc bror_32 = { X86_INS_ROR,    1, []( uint64_t d, const uint64_t a[] ) -> uint64_t {
+#ifdef _WIN32
+            return _rotr( ( uint32_t )d, ( int )a[ 0 ] );
+#else
+            return __rord( ( uint32_t )d, ( int )a[ 0 ] );
+#endif
+        }, 4 };
+        inline const arithmetic_operation_desc bror_16 = { X86_INS_ROR,    1, []( uint64_t d, const uint64_t a[] ) -> uint64_t {
+#ifdef _WIN32
+            return _rotr16( ( uint16_t )d, ( uint8_t )a[ 0 ] );
+#else
+            return __rorw( ( uint16_t )d, ( uint8_t )a[ 0 ] );
+#endif
+        }, 2 };
+        inline const arithmetic_operation_desc bror_8 = { X86_INS_ROR,    1, []( uint64_t d, const uint64_t a[] ) -> uint64_t {
+#ifdef _WIN32
+            return _rotr8( ( uint8_t )d, ( uint8_t )a[ 0 ] );
+#else
+            return __rorb( ( uint8_t )d, ( uint8_t )a[ 0 ] );
+#endif
+        }, 1 };
 
         // List of all operation descriptors.
         //

--- a/VMPAttack/arithmetic_utilities.hpp
+++ b/VMPAttack/arithmetic_utilities.hpp
@@ -7,7 +7,7 @@ namespace vmpattack
     template <typename T>
     inline T dynamic_size_cast( T value, size_t bytes )
     {
-        if ( bytes == sizeof T )
+        if ( bytes == sizeof( T ) )
             return value;
 
         T mask = ( 1ull << ( bytes * 8ull ) ) - 1ull;

--- a/VMPAttack/main.cpp
+++ b/VMPAttack/main.cpp
@@ -1,5 +1,6 @@
-
+#ifdef _WIN32
 #include <windows.h>
+#endif
 #include <cstdint>
 
 #include "vmpattack.hpp"
@@ -8,7 +9,9 @@
 #include <fstream>
 #include <filesystem>
 
+#ifdef _MSC_VER
 #pragma comment(linker, "/STACK:34359738368")
+#endif
 
 using namespace vtil;
 using namespace vtil::optimizer;
@@ -16,9 +19,11 @@ using namespace vtil::logger;
 
 namespace vmpattack
 {
+    using std::uint8_t;
+
     // Still hate c++
     //
-    std::vector<BYTE> read_file( const char* filename )
+    std::vector<uint8_t> read_file( const char* filename )
     {
         // open the file:
         std::ifstream file( filename, std::ios::binary );
@@ -34,13 +39,13 @@ namespace vmpattack
         file.seekg( 0, std::ios::beg );
 
         // reserve capacity
-        std::vector<BYTE> vec;
+        std::vector<uint8_t> vec;
         vec.reserve( fileSize );
 
         // read the data:
         vec.insert( vec.begin(),
-                    std::istream_iterator<BYTE>( file ),
-                    std::istream_iterator<BYTE>() );
+                    std::istream_iterator<uint8_t>( file ),
+                    std::istream_iterator<uint8_t>() );
 
         return vec;
     }

--- a/VMPAttack/vm_instance.cpp
+++ b/VMPAttack/vm_instance.cpp
@@ -123,7 +123,7 @@ namespace vmpattack
 
         // Create a new analysis context from the newly copied stream.
         //
-        analysis_context* peek_analysis_context = &analysis_context( &peek_stream );
+        analysis_context peek_analysis_context = analysis_context( &peek_stream );
 
         // The VIP is offseted by 4 at each handler; search for this so.
         //
@@ -131,7 +131,7 @@ namespace vmpattack
         x86_insn update_vip_ins;
 
         auto bridge_result = peek_analysis_context
-            ->update_reg( { update_vip_ins, false }, { vip_reg, true }, { vip_offset_size, true } );
+            .update_reg( { update_vip_ins, false }, { vip_reg, true }, { vip_offset_size, true } );
 
         // If nothing found, something went wrong; return empty {}.
         //


### PR DESCRIPTION
* Replace intrinsicts with their Clang/GCC counterparts
* Add CMake build system that fetches VTIL
* Replace Windows `BYTE` with portable `uint8_t`

Nothing in this CMakeLists is Linux-specific, so you should be able to build VMPAttack on Windows with CMake now as well.